### PR TITLE
Fix contrib.rocks link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ The next steps:
   <img src="https://contrib.rocks/image?repo=One-Language/Document" alt="The One Language Document Contributors">
 </a>
 
-Made with [contrib.rocks](https://contrib.rocks).
+Made with [contrib.rocks](https://contrib.rocks/preview?repo=One-Language%2FDocument).


### PR DESCRIPTION
Instead of the generic link to [contrib.rocks](https://contrib.rocks/), it now points to a specific preview page tailored for our repository: [contrib.rocks](https://contrib.rocks/preview?repo=One-Language%2FDocument).